### PR TITLE
Update lib/termsupport.zsh to account for tmux

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -13,9 +13,9 @@ function title {
   # if it is set and empty, leave it as is
   : ${2=$1}
 
-  if [[ "$TERM" == screen* ]]; then
+  if [[ "$TERM" == screen* ]] && [[ -z $TMUX ]]; then
     print -Pn "\ek$1:q\e\\" #set screen hardstatus, usually truncated at 20 chars
-  elif [[ "$TERM" == xterm* ]] || [[ "$TERM" == rxvt* ]] || [[ "$TERM" == ansi ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
+  elif [[ "$TERM" == xterm* ]] || [[ "$TERM" == rxvt* ]] || [[ "$TERM" == ansi ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]] || [[ -n $TMUX ]]; then
     print -Pn "\e]2;$2:q\a" #set window name
     print -Pn "\e]1;$1:q\a" #set icon (=tab) name
   fi


### PR DESCRIPTION
Since the default and recommended config for tmux sets TERM to screen or screen-256color, this file was attempting to set tmux's title using screen hardstatus. While tmux can be configured to accept these codes, it makes more sense to simply set the window name normally, so tmux can get the title from the active pane. This commit avoids using screen hardstatus when tmux is detected, and instead uses normal window codes.